### PR TITLE
Fix Encoding::UndefinedConversionError

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source :rubygems
 
 group :test, :development do
+  gem 'rake'
+  gem 'minitest'
   gem 'simplecov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,20 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    simplecov (0.4.2)
-      simplecov-html (~> 0.4.4)
-    simplecov-html (0.4.4)
+    docile (1.1.0)
+    minitest (5.0.8)
+    multi_json (1.8.2)
+    rake (10.1.0)
+    simplecov (0.8.2)
+      docile (~> 1.1.0)
+      multi_json
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  minitest
+  rake
   simplecov

--- a/README.rdoc
+++ b/README.rdoc
@@ -56,3 +56,7 @@ After that you can run the metric_fu/metrical command.
   !!     value * value
        end
      end
+
+= Running tests
+  bundle
+  rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'bundler'
+require 'bundler/setup'
 Bundler::GemHelper.install_tasks
 
 require 'rake/testtask'
@@ -6,3 +7,5 @@ require 'rake/testtask'
 Rake::TestTask.new do |t|
   t.pattern = "test/test_*.rb"
 end
+
+task :default => :test

--- a/lib/simplecov-rcov-text.rb
+++ b/lib/simplecov-rcov-text.rb
@@ -12,7 +12,7 @@ class SimpleCov::Formatter::RcovTextFormatter
   def format( result )
     FileUtils.mkdir_p(SimpleCov::Formatter::RcovTextFormatter.output_path)
 
-    File.open(File.join(SimpleCov::Formatter::RcovTextFormatter.output_path, SimpleCov::Formatter::RcovTextFormatter.file_name), "w+") do |rcov|
+    File.open(File.join(SimpleCov::Formatter::RcovTextFormatter.output_path, SimpleCov::Formatter::RcovTextFormatter.file_name), "wb+") do |rcov|
       rcov << create_content(result)
     end
   end

--- a/test/fixtures/some_class.rb
+++ b/test/fixtures/some_class.rb
@@ -6,4 +6,8 @@ class SomeClass
   def method_2 ( value )
     value * value
   end
+
+  def method_3
+    "über"
+  end
 end

--- a/test/test_simplecov-rcov-text.rb
+++ b/test/test_simplecov-rcov-text.rb
@@ -1,35 +1,44 @@
-require 'minitest/unit'
+require 'minitest'
 require 'minitest/autorun'
+require 'minitest/unit'
 require 'simplecov'
 
 require 'simplecov-rcov-text'
 
-class TestSimpleCovFormatterRcovTextFormatter < MiniTest::Unit::TestCase
+class TestSimpleCovFormatterRcovTextFormatter < MiniTest::Test
   def setup
     @rcov_file = File.join( SimpleCov::Formatter::RcovTextFormatter.output_path, SimpleCov::Formatter::RcovTextFormatter.file_name)
+    File.delete( @rcov_file ) if File.exists?( @rcov_file )
+
     @result = SimpleCov::Result.new(
       {
         File.expand_path( File.join( File.dirname( __FILE__ ), 'fixtures', 'some_class.rb' ) )  =>
-        [1,1,1,1,nil,1,0,1,1]
+        [1,1,1,1,nil,1,0,1,1,nil,0,1,1]
       }
     )
+
+    # Set to default encoding
+    Encoding.default_internal = nil if defined?(Encoding)
   end
 
   def test_format
-    if File.exists?( @rcov_file )
-      File.delete( @rcov_file )
-    end
-
     SimpleCov::Formatter::RcovTextFormatter.new.format( @result )
 
     assert File.exists?( @rcov_file )
+  end
+
+  def test_encoding
+    # This is done in many rails environments
+    Encoding.default_internal = 'UTF-8' if defined?(Encoding)
+
+    SimpleCov::Formatter::RcovTextFormatter.new.format( @result )
   end
 
   def test_create_content
     content = SimpleCov::Formatter::RcovTextFormatter.new.create_content( @result )
     test = "\="*80
 
-    assert_match /#{test}/,content
-    assert_match /!!     value \* value/,content
+    assert_match(/#{test}/, content)
+    assert_match(/!!     value \* value/, content)
   end
 end


### PR DESCRIPTION
This prevents certain kind of encoding issues from being thrown by Ruby. This probably started with the change in https://github.com/colszowka/simplecov/commit/6abb79e.
### Changes
- Updates to Gemfile/Rakefile so various ruby versions all work
- Bumped Simplecov version to 0.8.2 to elicit bad behavior
- Updated fixture and added test for issue
- Added test as default rake task
- Updated conventions for current Minitest version
