### PR TITLE
Remove automatic call to `Bundler.setup`

### DIFF
--- a/lib/simplecov-rcov-text.rb
+++ b/lib/simplecov-rcov-text.rb
@@ -1,5 +1,3 @@
-require 'bundler'
-Bundler.setup(:default)
 require 'cgi'
 require 'fileutils'
 require 'time'


### PR DESCRIPTION
Invoking `Bundler.setup` overrides previous invocations that could have been made from application side.

Example:
``` ruby
# spec_helper.rb
require 'bundler'
Bundler.setup(:default, :test)

require 'simplecov-rcov-text'
# from this point, all gems that belong to the :test scope are no longer available since the call
# to Bundler.setup made inside simplecov-rcov-text overrides the initial call to setup.
```